### PR TITLE
Add DBML support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 .asciidoctor/kroki
+.idea/

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Kroki currently supports the following diagram libraries:
 * [BPMN](https://github.com/bpmn-io/bpmn-js): `bpmn`
 * [Bytefield](https://github.com/Deep-Symmetry/bytefield-svg/): `bytefield`
 * [C4 (PlantUML)](https://github.com/RicardoNiepel/C4-PlantUML): `c4plantuml`
+* [DBML](https://www.dbml.org/home/): `dbml`
 * [Ditaa](http://ditaa.sourceforge.net): `ditaa`
 * [ERD](https://github.com/BurntSushi/erd): `erd`
 * [Excalidraw](https://github.com/excalidraw/excalidraw): `excalidraw`

--- a/dist/browser/asciidoctor-kroki.js
+++ b/dist/browser/asciidoctor-kroki.js
@@ -13106,7 +13106,7 @@ var IncomingMessage = exports.IncomingMessage = function (xhr, response, mode, r
 		self.url = response.url
 		self.statusCode = response.status
 		self.statusMessage = response.statusText
-		
+
 		response.headers.forEach(function (header, key){
 			self.headers[key.toLowerCase()] = header
 			self.rawHeaders.push(key, header)
@@ -18508,6 +18508,7 @@ module.exports.register = function register (registry, context = {}) {
     'bpmn',
     'bytefield',
     'c4plantuml',
+    'dbml',
     'ditaa',
     'erd',
     'excalidraw',

--- a/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
+++ b/ruby/lib/asciidoctor/extensions/asciidoctor_kroki/extension.rb
@@ -111,6 +111,7 @@ module AsciidoctorExtensions
       bpmn
       bytefield
       c4plantuml
+      dbml
       ditaa
       erd
       excalidraw

--- a/src/asciidoctor-kroki.js
+++ b/src/asciidoctor-kroki.js
@@ -224,6 +224,7 @@ module.exports.register = function register (registry, context = {}) {
     'bpmn',
     'bytefield',
     'c4plantuml',
+    'dbml',
     'ditaa',
     'erd',
     'excalidraw',


### PR DESCRIPTION
Since https://github.com/yuzutech/kroki/pull/1432, kroki (either from kroki.io or from up-to-date self-hosted instance) can convert DBML diagrams (see https://www.dbml.org/home/) to SVG using dbml-renderer (https://github.com/softwaretechnik-berlin/dbml-renderer).

This pull request only aims at forwarding this new support.